### PR TITLE
Allow custom read rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ const numberOfWords = rpm.words
 const langRate = rpm.rate
 ```
 
+### Alternative Use with a Custom Rate
+
+Simply pass the desired custom reading rate in words per minute instead of a language code:
+
+```javascript
+// For very fast readers: 425 words per minute.
+rpm.parse('Long text', 425)
+```
+
+**NOTE**:  The custom reading rate must be greater than zero or an error will be thrown.
+
 ## Rates
 
 Reading rates by lang come from ["How many words do we read per minute? A review and meta-analysis of reading rate"](https://osf.io/4nv9f/) by Marc Brysbaert - Department of Experimental Psychology Ghent University

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Simply pass the desired custom reading rate in words per minute instead of a lan
 rpm.parse('Long text', 425)
 ```
 
-**NOTE**:  The custom reading rate must be greater than zero or an error will be thrown.
+**NOTE**:  The custom reading rate must be greater than zero or the default value will be used.
 
 ## Rates
 

--- a/src/ReadPerMinute.js
+++ b/src/ReadPerMinute.js
@@ -31,14 +31,24 @@ class ReadPerMinute {
 	 * Parses a string, counts the number the words and divides it by the lang rate to get an estimated reading time.
 	 * The function returns an object containing the estimated time, the number of words and the rate used in the calculation.
 	 * @param text  {string}                                    String to parse.
-	 * @param lang  {string}                                    Lang used to retrieve the reading rate.
+	 * @param langOrRate  {string | number}                     Lang used to retrieve the reading rate, or a custom rate value.
 	 * @returns {{rate: number, words: number, time: number}}   Object containing the estimated time, the number of words and the rate used in the calculation.
 	 */
-	parse(text = '', lang = 'en') {
-		if (!ReadPerMinute.isLangExist(lang)) {
-			lang = 'default'
+	parse(text = '', langOrRate = 'en') {
+		let rate = 0;
+		if (typeof langOrRate === 'number') {
+			// Must be greater than zero.
+			if (langOrRate <= 0) {
+				throw new Error('The specified rate must be greater than zero.')
+			}
+			rate = langOrRate
 		}
-		const rate = ReadPerMinute.rates[lang]
+		else {
+			if (!ReadPerMinute.isLangExist(langOrRate)) {
+				langOrRate = 'default'
+			}
+			rate = ReadPerMinute.rates[langOrRate]
+		}
 
 		if (!text || !text.length) {
 			return {

--- a/src/ReadPerMinute.js
+++ b/src/ReadPerMinute.js
@@ -36,11 +36,7 @@ class ReadPerMinute {
 	 */
 	parse(text = '', langOrRate = 'en') {
 		let rate = 0;
-		if (typeof langOrRate === 'number') {
-			// Must be greater than zero.
-			if (langOrRate <= 0) {
-				throw new Error('The specified rate must be greater than zero.')
-			}
+		if (typeof langOrRate === 'number' && langOrRate > 0) {
 			rate = langOrRate
 		}
 		else {

--- a/src/ReadPerMinute.js
+++ b/src/ReadPerMinute.js
@@ -35,14 +35,10 @@ class ReadPerMinute {
 	 * @returns {{rate: number, words: number, time: number}}   Object containing the estimated time, the number of words and the rate used in the calculation.
 	 */
 	parse(text = '', langOrRate = 'en') {
-		let rate = 0;
-		if (typeof langOrRate === 'number' && langOrRate > 0) {
+		let rate = ReadPerMinute.rates['default'];
+		if (+langOrRate > 0) {
 			rate = langOrRate
-		}
-		else {
-			if (!ReadPerMinute.isLangExist(langOrRate)) {
-				langOrRate = 'default'
-			}
+		} else if (ReadPerMinute.isLangExist(langOrRate)) {
 			rate = ReadPerMinute.rates[langOrRate]
 		}
 

--- a/src/__tests__/ReadPerMinute.test.js
+++ b/src/__tests__/ReadPerMinute.test.js
@@ -146,5 +146,16 @@ describe('ReadPerMinute', () => {
 			const instance = new ReadPerMinute()
 			expect(instance.parse(text, lang)).not.toEqual(expected)
 		})
+
+		test.each([
+			[
+				generateTokenizedText(null, 425, 425).str,
+				425,
+				{ time: 1, words: 425, rate: 425 },
+			]
+		])('Parses text and uses the custom rate for calculations', (text, langOrRate, expected) => {
+			const instance = new ReadPerMinute()
+			expect(instance.parse(text, langOrRate)).toEqual(expected)
+		})
 	})
 })

--- a/src/__tests__/ReadPerMinute.test.js
+++ b/src/__tests__/ReadPerMinute.test.js
@@ -166,9 +166,10 @@ describe('ReadPerMinute', () => {
 				generateTokenizedText(null, 1, 1).str,
 				-1
 			],
-		])('Throws an error if the custom rate is invalid', (text, customRate) => {
+		])('Exchanges invalid numeric values with the default rate', (text, customRate) => {
 			const instance = new ReadPerMinute()
-			expect(() => instance.parse(text, customRate)).toThrowError()
+			const result = instance.parse(text, customRate)
+			expect(result.rate).to.equal(200);
 		})
 	})
 })

--- a/src/__tests__/ReadPerMinute.test.js
+++ b/src/__tests__/ReadPerMinute.test.js
@@ -169,7 +169,7 @@ describe('ReadPerMinute', () => {
 		])('Exchanges invalid numeric values with the default rate', (text, customRate) => {
 			const instance = new ReadPerMinute()
 			const result = instance.parse(text, customRate)
-			expect(result.rate).to.equal(200);
+			expect(result.rate).to.equal(ReadPerMinute.rates.default);
 		})
 	})
 })

--- a/src/__tests__/ReadPerMinute.test.js
+++ b/src/__tests__/ReadPerMinute.test.js
@@ -155,7 +155,7 @@ describe('ReadPerMinute', () => {
 			]
 		])('Parses text and uses a custom rate', (text, rate, expected) => {
 			const instance = new ReadPerMinute()
-			expect(instance.parse(text, langOrRate)).toEqual(expected)
+			expect(instance.parse(text, rate)).toEqual(expected)
 		})
 		test.each([
 			[

--- a/src/__tests__/ReadPerMinute.test.js
+++ b/src/__tests__/ReadPerMinute.test.js
@@ -153,7 +153,7 @@ describe('ReadPerMinute', () => {
 				425,
 				{ time: 1, words: 425, rate: 425 },
 			]
-		])('Parses text and uses the custom rate for calculations', (text, langOrRate, expected) => {
+		])('Parses text and uses a custom rate', (text, rate, expected) => {
 			const instance = new ReadPerMinute()
 			expect(instance.parse(text, langOrRate)).toEqual(expected)
 		})

--- a/src/__tests__/ReadPerMinute.test.js
+++ b/src/__tests__/ReadPerMinute.test.js
@@ -157,5 +157,18 @@ describe('ReadPerMinute', () => {
 			const instance = new ReadPerMinute()
 			expect(instance.parse(text, langOrRate)).toEqual(expected)
 		})
+		test.each([
+			[
+				generateTokenizedText(null, 1, 1).str,
+				0
+			],
+			[
+				generateTokenizedText(null, 1, 1).str,
+				-1
+			],
+		])('Throws an error if the custom rate is invalid', (text, customRate) => {
+			const instance = new ReadPerMinute()
+			expect(() => instance.parse(text, customRate)).toThrowError()
+		})
 	})
 })


### PR DESCRIPTION
This PR enables the use of custom read rates.

## Motivation

This gives applications an opportunity to customize the estimation in a per-user basis, as not all users read at the same rate.  While sensible averages are a good start, the best user experience lies in the ability to tailor the application to the user's needs.